### PR TITLE
update cli to check for commit hash diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align=center>
-    <a href="https://pypi.org/project/kern-refinery/1.0.2/"><img src="https://img.shields.io/badge/pypi-1.0.2-yellow.svg" alt="pypi 1.0.2"></a>
+    <a href="https://pypi.org/project/kern-refinery/1.0.3/"><img src="https://img.shields.io/badge/pypi-1.0.3-yellow.svg" alt="pypi 1.0.3"></a>
     <a href="https://github.com/code-kern-ai/refinery/blob/master/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-success" alt="Apache 2.0 License"></a>
     <a href="https://github.com/code-kern-ai/refinery/discussions"><img src="https://img.shields.io/badge/Discussions-gray.svg?logo=github" alt="GitHub Discussions"></a>
     <a href="https://discord.gg/qf4rGCEphW"><img src="https://img.shields.io/badge/Discord-gray.svg?logo=discord" alt="Discord"></a>

--- a/refinery/cli.py
+++ b/refinery/cli.py
@@ -1,11 +1,12 @@
 import os
-from contextlib import contextmanager
 import sys
 import platform
 import subprocess
+import re
 from git import Repo
 from wasabi import msg
 
+REFINERY_REPO = "https://github.com/code-kern-ai/refinery"
 REFINERY_FOLDER = "refinery"
 
 
@@ -16,7 +17,29 @@ def start(cur_dir: str):
         cur_dir (str): The current directory.
     """
 
-    def _start_server():
+    def _start_server(check_for_update: bool):
+
+        if check_for_update:
+            repo = Repo(search_parent_directories=True)
+            sha_local = repo.head.object.hexsha
+
+            # https://stackoverflow.com/questions/62525382/how-to-get-the-latest-commit-hash-on-remote-using-gitpython
+            repo_url = f"{REFINERY_REPO}.git"
+            process = subprocess.Popen(
+                ["git", "ls-remote", repo_url], stdout=subprocess.PIPE
+            )
+            stdout, stderr = process.communicate()
+            sha_remote = re.split(r"\t+", stdout.decode("ascii"))[0]
+
+            if sha_local != sha_remote:
+                user_input = input(
+                    "A new version of refinery is available. Should this be pulled? (y/n)"
+                )
+                if user_input == "y":
+                    repo_origin = repo.remotes.origin
+                    repo_origin.pull()
+                    msg.good("refinery has been updated.")
+
         if platform.system() == "Windows":
             subprocess.run(["start.bat"])
         else:
@@ -26,14 +49,14 @@ def start(cur_dir: str):
         msg.info(
             f"Cloning from code-kern-ai/refinery into repository {REFINERY_FOLDER}"
         )
-        Repo.clone_from("https://github.com/code-kern-ai/refinery", REFINERY_FOLDER)
+        Repo.clone_from(REFINERY_REPO, REFINERY_FOLDER)
         with cd(REFINERY_FOLDER):
-            _start_server()
+            _start_server(check_for_update=False)
     elif cur_dir == REFINERY_FOLDER:
-        _start_server()
+        _start_server(check_for_update=True)
     else:
         with cd(REFINERY_FOLDER):
-            _start_server()
+            _start_server(check_for_update=True)
 
 
 def stop(cur_dir: str):

--- a/refinery/cli.py
+++ b/refinery/cli.py
@@ -32,13 +32,16 @@ def start(cur_dir: str):
             sha_remote = re.split(r"\t+", stdout.decode("ascii"))[0]
 
             if sha_local != sha_remote:
-                user_input = input(
+                msg.info(
                     "A new version of refinery is available. Should this be pulled? (y/n)"
                 )
+                user_input = input("> ")
                 if user_input == "y":
                     repo_origin = repo.remotes.origin
                     repo_origin.pull()
-                    msg.good("refinery has been updated.")
+                    msg.good(f"refinery has been updated to commit {sha_remote}.")
+                else:
+                    msg.info(f"Staying on commit {sha_local}.")
 
         if platform.system() == "Windows":
             subprocess.run(["start.bat"])

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(this_directory, "README.md"), encoding="utf8") as file:
 
 setup(
     name="kern-refinery",
-    version="1.0.2",
+    version="1.0.3",
     author="jhoetter",
     author_email="johannes.hoetter@kern.ai",
     description="The open-source data-centric IDE for NLP.",


### PR DESCRIPTION
To test, run `pip install -e .` inside the repository to build the newest CLI. Afterward, you can run `refinery start`

This should let you know once running `refinery start` that there is an updated version available, which you can pull via user input `y`.