### PR TITLE
adds update and help CLI commands, bumps to version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align=center>
-    <a href="https://pypi.org/project/kern-refinery/1.0.3/"><img src="https://img.shields.io/badge/pypi-1.0.3-yellow.svg" alt="pypi 1.0.3"></a>
+    <a href="https://pypi.org/project/kern-refinery/1.1.0/"><img src="https://img.shields.io/badge/pypi-1.1.0-yellow.svg" alt="pypi 1.1.0"></a>
     <a href="https://github.com/code-kern-ai/refinery/blob/master/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-success" alt="Apache 2.0 License"></a>
     <a href="https://github.com/code-kern-ai/refinery/discussions"><img src="https://img.shields.io/badge/Discussions-gray.svg?logo=github" alt="GitHub Discussions"></a>
     <a href="https://discord.gg/qf4rGCEphW"><img src="https://img.shields.io/badge/Discord-gray.svg?logo=discord" alt="Discord"></a>

--- a/refinery/cli.py
+++ b/refinery/cli.py
@@ -91,6 +91,35 @@ def stop(cur_dir: str):
         msg.fail(f"Could not find repository {REFINERY_FOLDER}.")
 
 
+def update(cur_dir: str):
+    """Updates the refinery repository.
+
+    Args:
+        cur_dir (str): The current directory.
+    """
+
+    def _update():
+        if platform.system() == "Windows":
+            subprocess.run(["update.bat"])
+        else:
+            subprocess.run(["./update"])
+
+    if cur_dir == REFINERY_FOLDER:
+        _update()
+    elif os.path.exists(REFINERY_FOLDER):
+        with cd(REFINERY_FOLDER):
+            _update()
+    else:
+        msg.fail(f"Could not find repository {REFINERY_FOLDER}.")
+
+
+def help():
+    msg.info("Available commands:")
+    msg.info(" - `refinery start` to start the server")
+    msg.info(" - `refinery stop` to end it")
+    msg.info(" - `refinery update` to update the repository")
+
+
 def main():
     cli_args = sys.argv[1:]
     if len(cli_args) == 0:
@@ -102,6 +131,10 @@ def main():
         start(cur_dir)
     elif command == "stop":
         stop(cur_dir)
+    elif command == "update":
+        update(cur_dir)
+    elif command == "help":
+        help()
     else:
         msg.fail(
             f"Could not understand command `{command}`. Type `refinery help` for some instructions."

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(this_directory, "README.md"), encoding="utf8") as file:
 
 setup(
     name="kern-refinery",
-    version="1.0.3",
+    version="1.1.0",
     author="jhoetter",
     author_email="johannes.hoetter@kern.ai",
     description="The open-source data-centric IDE for NLP.",


### PR DESCRIPTION
In the repository, run `pip install -e .` to install the library from local setup.
Afterwards, run:
- `refinery help`
- `refinery update`

When doing so, the new version should be installed after running `refinery start` afterwards